### PR TITLE
advanced/name_and_value_mapper: fix invalid Go code

### DIFF
--- a/en-US/advanced/name_and_value_mapper.md
+++ b/en-US/advanced/name_and_value_mapper.md
@@ -43,7 +43,7 @@ type Env struct {
 }
 
 func main() {
-	cfg, err := ini.Load([]byte("[env]\nfoo = ${MY_VAR}\n")
+	cfg, err := ini.Load([]byte("[env]\nfoo = ${MY_VAR}\n"))
 	cfg.ValueMapper = os.ExpandEnv
 	// ...
 	env := &Env{}

--- a/zh-CN/advanced/name_and_value_mapper.md
+++ b/zh-CN/advanced/name_and_value_mapper.md
@@ -43,7 +43,7 @@ type Env struct {
 }
 
 func main() {
-	cfg, err := ini.Load([]byte("[env]\nfoo = ${MY_VAR}\n")
+	cfg, err := ini.Load([]byte("[env]\nfoo = ${MY_VAR}\n"))
 	cfg.ValueMapper = os.ExpandEnv
 	// ...
 	env := &Env{}


### PR DESCRIPTION
One of the examples in 'advanced/name_and_value_mapper' is missing an
end parenthesis which means the Go example won't compile. Added the
missing parenthesis to the broken example for both 'en-US' and 'zh-CN'
languages.